### PR TITLE
fix use correct database on autoDatabase

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -127,11 +127,11 @@ class ImmudbClient {
     if (autoLogin && autoDatabase) {
       // get current database list
       const resList = await this.listDatabases();
-      if (resList && resList.databasesList.some(db => db.databasename === databasename)) {
+      if (databasename && resList && resList.databasesList.some(db => db.databasename === databasename)) {
         // useDatabase database specified if it
         // already exists
-        await this.useDatabase({ databasename: DEFAULT_DATABASE });
-        console.log(`${CLIENT_INIT_PREFIX} useDatabase  '${DEFAULT_DATABASE}'`);
+        await this.useDatabase({ databasename });
+        console.log(`${CLIENT_INIT_PREFIX} useDatabase '${databasename}'`);
       } else if (databasename) {
         // run createDatabase and useDatabase if databasename
         // is different than the default one
@@ -143,7 +143,7 @@ class ImmudbClient {
         // run createDatabase and useDatabase if default
         // databasename is missing
         await this.useDatabase({ databasename: DEFAULT_DATABASE });
-        console.log(`${CLIENT_INIT_PREFIX} useDatabase '${databasename}'`);
+        console.log(`${CLIENT_INIT_PREFIX} useDatabase '${DEFAULT_DATABASE}'`);
       }
     } else {
       console.log(

--- a/tests/tap-parallel-not-ok/client.ts
+++ b/tests/tap-parallel-not-ok/client.ts
@@ -13,6 +13,28 @@ const {
   IMMUDB_PWD = 'immudb',
 } = process.env;
 
+tap.test('[DATABASE AUTOLOGIN & AUTODATABASE]', async t => {
+  const notADefaultDB = "notadefaultdb";
+
+  const config: Config = {
+    host: IMMUDB_HOST,
+    port: IMMUDB_PORT,
+    database: notADefaultDB
+  };
+
+  const immudbClient = await ImmudbClient.getInstance(config);
+
+  try {
+    const currentStateResponse =  await immudbClient.currentState();
+
+    t.equal(currentStateResponse?.db, notADefaultDB);
+
+    t.end();
+  } catch (err) {
+    t.error(err);
+  }
+});
+
 tap.test('[DATABASE MANAGEMENT]', async t => {
   const config: Config = {
     host: IMMUDB_HOST,


### PR DESCRIPTION
Hello,

I've found a bug when using autoLogin & autoDatabase that it was using the default db instead of using the database from the Config.

Feel free to comment or change anything

Thanks!